### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["default"]
 description = "The std Default derive, but it allows to constomize the default fields values and has some upgrades."
 exclude = ["./scripts"]
 readme = "./README.md"
-homepage = "https://github.com/NovaliX-Dev/better_default"
+repository = "https://github.com/NovaliX-Dev/better_default"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.